### PR TITLE
fix(#16): cros mist-farm.online 도메인 허용

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,12 @@ async function bootstrap() {
     .addServer('http://localhost:3000/', '로컬 환경')
     .build();
 
+  app.enableCors({
+    origin: 'https://mist-farm.online', // 허용할 도메인
+    methods: 'GET,POST,PUT,PATCH,DELETE',
+    credentials: true, // 쿠키 허용 시
+  });
+
   const document = SwaggerModule.createDocument(app, options);
   SwaggerModule.setup('api-docs', app, document);
   app.useGlobalPipes(new ValidationPipe());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타 (Chores)**
  * 외부 도메인(https://mist-farm.online)과의 통신을 지원하도록 CORS 설정을 추가하여 GET, POST, PUT, PATCH, DELETE 요청 및 인증 정보 전송을 활성화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->