### PR TITLE
fix(#16): cors https://mistfarm.vercel.app/ 도메인 허용으로 변경

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ async function bootstrap() {
     .build();
 
   app.enableCors({
-    origin: 'https://mist-farm.online', // 허용할 도메인
+    origin: 'https://mistfarm.vercel.app', // 허용할 도메인
     methods: 'GET,POST,PUT,PATCH,DELETE',
     credentials: true, // 쿠키 허용 시
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타**
  * 애플리케이션의 허용 CORS 원본을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->