### PR TITLE
fix(#16): 에러메세지 '아이디이' -> '아이디가'로 변경

### DIFF
--- a/src/domain/auth/auth.service.ts
+++ b/src/domain/auth/auth.service.ts
@@ -36,7 +36,7 @@ export class AuthService {
     const user = await this.userRepo.findById(id);
 
     if (!user) {
-      throw new BadRequestException('아이디이 존재하지 않습니다');
+      throw new BadRequestException('아이디가 존재하지 않습니다');
     }
 
     const isPasswordValid = await bcrypt.compare(password, user.password);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 로그인 실패 시 사용자 ID 관련 오류 메시지 문구를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->